### PR TITLE
Add date flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,6 +88,10 @@ func (d *snapshotDate) String() string {
 }
 
 func (d *snapshotDate) Set(s string) error {
+	if s == "" {
+		*d = snapshotDate(time.Now())
+		return nil
+	}
 	t, err := time.Parse(options.DateFormat, s)
 	if err != nil {
 		return err
@@ -140,11 +144,11 @@ func (o *Options) Validate() error {
 }
 
 func (o *Options) RepositoryName() string {
-	return time.Now().Format(o.RepositoryFormat)
+	return time.Time(o.Date).Format(o.RepositoryFormat)
 }
 
 func (o *Options) SnapshotName() string {
-	return time.Now().Format(o.SnapshotFormat)
+	return time.Time(o.Date).Format(o.SnapshotFormat)
 }
 
 func (o *Options) RetryInterval() time.Duration {

--- a/main.go
+++ b/main.go
@@ -76,6 +76,24 @@ type Options struct {
 	SecretKey string
 
 	Restore bool
+
+	Date       snapshotDate
+	DateFormat string
+}
+
+type snapshotDate time.Time
+
+func (d *snapshotDate) String() string {
+	return time.Time(*d).Format(options.DateFormat)
+}
+
+func (d *snapshotDate) Set(s string) error {
+	t, err := time.Parse(options.DateFormat, s)
+	if err != nil {
+		return err
+	}
+	*d = snapshotDate(t)
+	return nil
 }
 
 func (o *Options) Validate() error {
@@ -163,6 +181,8 @@ func main() {
 	flag.StringVar(&options.Region, "region", "", "s3 region")
 	flag.StringVar(&options.AccessKey, "access-key", "", "s3 access key")
 	flag.StringVar(&options.SecretKey, "secret-key", "", "s3 secret key")
+	flag.Var(&options.Date, "date", "date taken snapshot")
+	flag.StringVar(&options.DateFormat, "date-format", "20060102", "date format")
 
 	flag.Parse()
 	if err := options.Validate(); err != nil {

--- a/main.go
+++ b/main.go
@@ -88,10 +88,6 @@ func (d *snapshotDate) String() string {
 }
 
 func (d *snapshotDate) Set(s string) error {
-	if s == "" {
-		*d = snapshotDate(time.Now())
-		return nil
-	}
 	t, err := time.Parse(options.DateFormat, s)
 	if err != nil {
 		return err
@@ -169,7 +165,9 @@ func (o *Options) SnapshotRepository() SnapshotRepository {
 }
 
 var (
-	options Options
+	options = Options{
+		Date: snapshotDate(time.Now()),
+	}
 )
 
 func main() {
@@ -189,6 +187,7 @@ func main() {
 	flag.StringVar(&options.DateFormat, "date-format", "20060102", "date format")
 
 	flag.Parse()
+
 	if err := options.Validate(); err != nil {
 		log.Fatalf("failed to parse flag: %v", err)
 	}


### PR DESCRIPTION
## WHY

Currently, only use `time.Now()` as snapshot repository name.

## WHAT

Receive `-date` flag.