### PR TITLE
Add indices option

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ type Options struct {
 	ServiceName string
 	Env         string
 	URL         string
+	Indices     string
 
 	RepositoryFormat string
 	SnapshotFormat   string
@@ -175,6 +176,7 @@ func main() {
 	flag.StringVar(&options.ServiceName, "service-name", "", "service name")
 	flag.StringVar(&options.Env, "env", "", "env")
 	flag.StringVar(&options.URL, "url", "http://localhost:9200", "URL for Elasticsearch")
+	flag.StringVar(&options.Indices, "indices", "-.*", "target indices")
 	flag.StringVar(&options.RepositoryFormat, "repository-format", "200601", "format of repository name")
 	flag.StringVar(&options.SnapshotFormat, "snapshot-format", "02", "format of snapshot name")
 	flag.StringVar(&options.RetryIntervalStr, "retry-interval", "1m", "retry interval for API request")
@@ -229,7 +231,7 @@ func createSnapshot() error {
 	_, _, errs := gorequest.New().
 		Retry(options.MaxRetries, options.RetryInterval(), http.StatusGatewayTimeout).
 		Put(requestURL).
-		Send(&SnapshotSettings{Indices: "*"}).
+		Send(&SnapshotSettings{Indices: options.Indices}).
 		End()
 	if len(errs) > 0 {
 		buf := ""
@@ -291,7 +293,7 @@ func restoreSnapshot() error {
 	_, _, errs = gorequest.New().
 		Retry(options.MaxRetries, options.RetryInterval(), http.StatusGatewayTimeout).
 		Post(requestURL).
-		Send(&SnapshotSettings{Indices: "*"}).
+		Send(&SnapshotSettings{Indices: options.Indices}).
 		End()
 	if len(errs) > 0 {
 		buf := ""

--- a/main.go
+++ b/main.go
@@ -176,7 +176,7 @@ func main() {
 	flag.StringVar(&options.ServiceName, "service-name", "", "service name")
 	flag.StringVar(&options.Env, "env", "", "env")
 	flag.StringVar(&options.URL, "url", "http://localhost:9200", "URL for Elasticsearch")
-	flag.StringVar(&options.Indices, "indices", "-.*", "target indices")
+	flag.StringVar(&options.Indices, "indices", "*,-.*", "target indices")
 	flag.StringVar(&options.RepositoryFormat, "repository-format", "200601", "format of repository name")
 	flag.StringVar(&options.SnapshotFormat, "snapshot-format", "02", "format of snapshot name")
 	flag.StringVar(&options.RetryIntervalStr, "retry-interval", "1m", "retry interval for API request")

--- a/main.go
+++ b/main.go
@@ -237,7 +237,7 @@ func createSnapshot() error {
 		Retry(options.MaxRetries, options.RetryInterval(), http.StatusGatewayTimeout).
 		Put(requestURL).
 		Send(&SnapshotSettings{
-      Indices: options.Indices,
+			Indices:            options.Indices,
 			IgnoreUnavailable:  options.IgnoreUnavailable,
 			IncludeGlobalState: options.IncludeGlobalState,
 		}).

--- a/main.go
+++ b/main.go
@@ -302,7 +302,8 @@ func restoreSnapshot() error {
 	_, _, errs = gorequest.New().
 		Retry(options.MaxRetries, options.RetryInterval(), http.StatusGatewayTimeout).
 		Post(requestURL).
-		Send(&SnapshotSettings{Indices: options.Indices,
+		Send(&SnapshotSettings{
+			Indices:            options.Indices,
 			IgnoreUnavailable:  options.IgnoreUnavailable,
 			IncludeGlobalState: options.IncludeGlobalState,
 		}).


### PR DESCRIPTION
## WHY

X-Pack has enabled since Elasticsearch v6. X-Pack creates indices, which has `.` prefix for watches and monitoring. I expect to restore all indices except which has `.` prefix.

## WHAT

I added `--indices` option, and set default value to `*,-.*`.
(all indices except which has `.` prefix)